### PR TITLE
fix for windows build

### DIFF
--- a/unix/stb_image.h
+++ b/unix/stb_image.h
@@ -329,7 +329,11 @@ extern "C" {
 #ifdef STB_IMAGE_STATIC
 #define STBIDEF static
 #else
+#ifdef _WIN32
+#define STBIDEF extern __declspec(dllexport)
+#else
 #define STBIDEF extern
+#endif
 #endif
 
 //////////////////////////////////////////////////////////////////////////////

--- a/unix/stb_image_write.h
+++ b/unix/stb_image_write.h
@@ -156,7 +156,11 @@ LICENSE
 #ifdef __cplusplus
 #define STBIWDEF  extern "C"
 #else
-#define STBIWDEF  extern
+#ifdef _WIN32
+#define STBIWDEF extern __declspec(dllexport)
+#else
+#define STBIWDEF extern
+#endif
 #endif
 #endif
 #endif


### PR DESCRIPTION
This fixes an issue with missing symbols on Windows in bimage-unix. See also discussion here: [Runtime error on missing symbols on Windows](https://discuss.ocaml.org/t/runtime-error-on-missing-symbols-on-windows/5416)
